### PR TITLE
fix: ts errors + quickstart readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Quick Start
+
+## Yaci DevKit Setup (Local Devnet)
+
+### Install Yaci DevKit
+
+```
+npm install -g @bloxbean/yaci-devkit
+```
+
+### Start local devnet
+
+```
+yaci-devkit up --enable-yaci-store --interactive
+```
+
+> **(Optional)** Open Yaci Viewer in another terminal:
+>
+>```
+>yaci-viewer
+>```
+>
+> A handy mini explorer to watch your local devnet activity
+
+## Run the template
+
+```bash
+npm install
+npm run aiken  # Build smart contracts
+npm run dev    # Test all contracts
+```
+
+That's it! The template will automatically use your local/hosted Yaci devnet to test smart contracts.
+
+## Resources
+
+- [Mesh SDK](https://meshjs.dev/)
+- [Yaci Devkit](https://devkit.yaci.xyz/)
+- [Aiken](https://aiken-lang.org)

--- a/mesh/common.ts
+++ b/mesh/common.ts
@@ -49,7 +49,7 @@ export const newWallet = (providedMnemonic?: string[]) => {
 };
 
 export class MeshTx {
-  constructor(public wallet: MeshWallet) { }
+  constructor(public wallet: MeshWallet) {}
 
   newTx = async () => {
     const address = (await this.wallet.getUsedAddresses())[0];

--- a/mesh/transactions/tx.ts
+++ b/mesh/transactions/tx.ts
@@ -43,7 +43,8 @@ export class MeshContractTx extends MeshTx {
   };
 
   lockAndRegisterCert = async () => {
-    const ownPubKey = deserializeAddress(this.address).pubKeyHash;
+    const address = (await this.wallet.getUsedAddresses())[0];
+    const ownPubKey = deserializeAddress(address).pubKeyHash;
     const spendingScriptCbor = applyCborEncoding(spendingScriptCompiledCode);
     const validatorAddress = serializePlutusScript({
       code: spendingScriptCbor,
@@ -72,7 +73,8 @@ export class MeshContractTx extends MeshTx {
   };
 
   unlockHelloWorld = async () => {
-    const ownPubKey = deserializeAddress(this.address).pubKeyHash;
+    const address = (await this.wallet.getUsedAddresses())[0];
+    const ownPubKey = deserializeAddress(address).pubKeyHash;
     const spendingScriptCbor = applyCborEncoding(spendingScriptCompiledCode);
     const validatorAddress = serializePlutusScript({
       code: spendingScriptCbor,
@@ -111,7 +113,8 @@ export class MeshContractTx extends MeshTx {
   };
 
   withdrawZero = async () => {
-    const ownPubKey = deserializeAddress(this.address).pubKeyHash;
+    const address = (await this.wallet.getUsedAddresses())[0];
+    const ownPubKey = deserializeAddress(address).pubKeyHash;
     const withdrawScriptCbor = applyParamsToScript(
       withdrawScriptCompiledCode,
       [ownPubKey],
@@ -136,7 +139,8 @@ export class MeshContractTx extends MeshTx {
   };
 
   deregisterStake = async () => {
-    const ownPubKey = deserializeAddress(this.address).pubKeyHash;
+    const address = (await this.wallet.getUsedAddresses())[0];
+    const ownPubKey = deserializeAddress(address).pubKeyHash;
     const withdrawScriptCbor = applyParamsToScript(
       withdrawScriptCompiledCode,
       [ownPubKey],


### PR DESCRIPTION
- Found a couple of ts errors that were breaking the template. `this.wallet.signTx()` calls weren't being awaited and there were references to `this.address` that didn't exist on the class.

- Switched from axios calls to MeshJS APIs and updated defaults from hosted Yaci (im not sure if the hosted version works rn) to localhost so the template works out-of-the-box with local Yaci DevKit. (I think some stuff in this template was just outdated as I think there are now "admin functions" for these) (switched to `addressTopup()` and `getGenesisByEra()` methods

- And I added a small quick start guide in the README

Now it compiles cleanly and works with local Yaci DevKit without any extra setup and we can onboard FASTER
